### PR TITLE
Add dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in fluent-plugin-cloudwatch.gemspec
+gemspec

--- a/fluent-plugin-cloudwatch_ya.gemspec
+++ b/fluent-plugin-cloudwatch_ya.gemspec
@@ -15,5 +15,8 @@ Gem::Specification.new do |gem|
     "README.md",
     "lib/fluent/plugin/out_cloudwatch_ya.rb"
   ]
+  gem.add_dependency "fluentd", [">= 0.10.0", "< 2"]
+  gem.add_dependency "aws-sdk-v1", "~> 1.38"
+  gem.add_dependency "jsonpath", "~> 0.5.0"
 end
 

--- a/lib/fluent/plugin/out_cloudwatch_ya.rb
+++ b/lib/fluent/plugin/out_cloudwatch_ya.rb
@@ -1,7 +1,7 @@
 module Fluent
     require 'net/http'
     require 'jsonpath'
-    require 'aws-sdk'
+    require 'aws-sdk-v1'
     class CloudWatchYaOutput < TimeSlicedOutput
 
         METRIC_DATA_MAX_NUM = 20 


### PR DESCRIPTION
`aws-sdk` gem contains breaking changes between 1.x and 2.x.
So I pinned aws-sdk-v1 gem version.
