### PR TITLE
Add secret parameters

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_ya.rb
+++ b/lib/fluent/plugin/out_cloudwatch_ya.rb
@@ -6,8 +6,8 @@ module Fluent
 
         METRIC_DATA_MAX_NUM = 20 
         Fluent::Plugin.register_output('cloudwatch_ya', self)
-        config_param :aws_key_id,                  :string, :default => nil
-        config_param :aws_sec_key,                 :string, :default => nil
+        config_param :aws_key_id,                  :string, :default => nil, :secret => true
+        config_param :aws_sec_key,                 :string, :default => nil, :secret => true
         config_param :cloud_watch_endpoint,        :string, :default => 'monitoring.ap-northeast-1.amazonaws.com'
         config_param :namespace,                   :string
 


### PR DESCRIPTION
Fluentd 0.12.13 or later supports secret parameter feature.
https://github.com/fluent/fluentd/blob/4e3a4ecb/ChangeLog#L34

If users use older version of fluentd, it should be simply ignored.
